### PR TITLE
Fix: Don't call methods that aren't available in the node environment

### DIFF
--- a/src/js/browser.js
+++ b/src/js/browser.js
@@ -36,68 +36,74 @@ var browser = {
     msie: false,
     edge: false,
     others: false,
-    version: 0
+    version: 0,
+    node: false
 };
 
-var nav = window.navigator;
-var appName = nav.appName.replace(/\s/g, '_');
-var userAgent = nav.userAgent;
+if (window && window.navigator) {
+  var nav = window.navigator;
+  var appName = nav.appName.replace(/\s/g, '_');
+  var userAgent = nav.userAgent;
 
-var rIE = /MSIE\s([0-9]+[.0-9]*)/;
-var rIE11 = /Trident.*rv:11\./;
-var rEdge = /Edge\/(\d+)\./;
-var versionRegex = {
-    firefox: /Firefox\/(\d+)\./,
-    chrome: /Chrome\/(\d+)\./,
-    safari: /Version\/([\d.]+).*Safari\/(\d+)/
-};
+  var rIE = /MSIE\s([0-9]+[.0-9]*)/;
+  var rIE11 = /Trident.*rv:11\./;
+  var rEdge = /Edge\/(\d+)\./;
+  var versionRegex = {
+      firefox: /Firefox\/(\d+)\./,
+      chrome: /Chrome\/(\d+)\./,
+      safari: /Version\/([\d.]+).*Safari\/(\d+)/
+  };
 
-var key, tmp;
+  var key, tmp;
 
-var detector = {
-    Microsoft_Internet_Explorer: function() { // eslint-disable-line camelcase
-        var detectedVersion = userAgent.match(rIE);
+  var detector = {
+      Microsoft_Internet_Explorer: function() { // eslint-disable-line camelcase
+          var detectedVersion = userAgent.match(rIE);
 
-        if (detectedVersion) { // ie8 ~ ie10
-            browser.msie = true;
-            browser.version = parseFloat(detectedVersion[1]);
-        } else { // no version information
-            browser.others = true;
-        }
-    },
-    Netscape: function() { // eslint-disable-line complexity
-        var detected = false;
+          if (detectedVersion) { // ie8 ~ ie10
+              browser.msie = true;
+              browser.version = parseFloat(detectedVersion[1]);
+          } else { // no version information
+              browser.others = true;
+          }
+      },
+      Netscape: function() { // eslint-disable-line complexity
+          var detected = false;
 
-        if (rIE11.exec(userAgent)) {
-            browser.msie = true;
-            browser.version = 11;
-            detected = true;
-        } else if (rEdge.exec(userAgent)) {
-            browser.edge = true;
-            browser.version = userAgent.match(rEdge)[1];
-            detected = true;
-        } else {
-            for (key in versionRegex) {
-                if (versionRegex.hasOwnProperty(key)) {
-                    tmp = userAgent.match(versionRegex[key]);
-                    if (tmp && tmp.length > 1) { // eslint-disable-line max-depth
-                        browser[key] = detected = true;
-                        browser.version = parseFloat(tmp[1] || 0);
-                        break;
-                    }
-                }
-            }
-        }
-        if (!detected) {
-            browser.others = true;
-        }
-    }
-};
+          if (rIE11.exec(userAgent)) {
+              browser.msie = true;
+              browser.version = 11;
+              detected = true;
+          } else if (rEdge.exec(userAgent)) {
+              browser.edge = true;
+              browser.version = userAgent.match(rEdge)[1];
+              detected = true;
+          } else {
+              for (key in versionRegex) {
+                  if (versionRegex.hasOwnProperty(key)) {
+                      tmp = userAgent.match(versionRegex[key]);
+                      if (tmp && tmp.length > 1) { // eslint-disable-line max-depth
+                          browser[key] = detected = true;
+                          browser.version = parseFloat(tmp[1] || 0);
+                          break;
+                      }
+                  }
+              }
+          }
+          if (!detected) {
+              browser.others = true;
+          }
+      }
+  };
 
-var fn = detector[appName];
+  var fn = detector[appName];
 
-if (fn) {
-    detector[appName]();
+  if (fn) {
+      detector[appName]();
+  }
+}
+else {
+  browser.node = true
 }
 
 module.exports = browser;

--- a/src/js/browser.js
+++ b/src/js/browser.js
@@ -36,74 +36,70 @@ var browser = {
     msie: false,
     edge: false,
     others: false,
-    version: 0,
-    node: false
+    version: 0
 };
 
 if (window && window.navigator) {
-  var nav = window.navigator;
-  var appName = nav.appName.replace(/\s/g, '_');
-  var userAgent = nav.userAgent;
+    var nav = window.navigator;
+    var appName = nav.appName.replace(/\s/g, '_');
+    var userAgent = nav.userAgent;
 
-  var rIE = /MSIE\s([0-9]+[.0-9]*)/;
-  var rIE11 = /Trident.*rv:11\./;
-  var rEdge = /Edge\/(\d+)\./;
-  var versionRegex = {
-      firefox: /Firefox\/(\d+)\./,
-      chrome: /Chrome\/(\d+)\./,
-      safari: /Version\/([\d.]+).*Safari\/(\d+)/
-  };
+    var rIE = /MSIE\s([0-9]+[.0-9]*)/;
+    var rIE11 = /Trident.*rv:11\./;
+    var rEdge = /Edge\/(\d+)\./;
+    var versionRegex = {
+        firefox: /Firefox\/(\d+)\./,
+        chrome: /Chrome\/(\d+)\./,
+        safari: /Version\/([\d.]+).*Safari\/(\d+)/
+    };
 
-  var key, tmp;
+    var key, tmp;
 
-  var detector = {
-      Microsoft_Internet_Explorer: function() { // eslint-disable-line camelcase
-          var detectedVersion = userAgent.match(rIE);
+    var detector = {
+        Microsoft_Internet_Explorer: function() { // eslint-disable-line camelcase
+            var detectedVersion = userAgent.match(rIE);
 
-          if (detectedVersion) { // ie8 ~ ie10
-              browser.msie = true;
-              browser.version = parseFloat(detectedVersion[1]);
-          } else { // no version information
-              browser.others = true;
-          }
-      },
-      Netscape: function() { // eslint-disable-line complexity
-          var detected = false;
+            if (detectedVersion) { // ie8 ~ ie10
+                browser.msie = true;
+                browser.version = parseFloat(detectedVersion[1]);
+            } else { // no version information
+                browser.others = true;
+            }
+        },
+        Netscape: function() { // eslint-disable-line complexity
+            var detected = false;
 
-          if (rIE11.exec(userAgent)) {
-              browser.msie = true;
-              browser.version = 11;
-              detected = true;
-          } else if (rEdge.exec(userAgent)) {
-              browser.edge = true;
-              browser.version = userAgent.match(rEdge)[1];
-              detected = true;
-          } else {
-              for (key in versionRegex) {
-                  if (versionRegex.hasOwnProperty(key)) {
-                      tmp = userAgent.match(versionRegex[key]);
-                      if (tmp && tmp.length > 1) { // eslint-disable-line max-depth
-                          browser[key] = detected = true;
-                          browser.version = parseFloat(tmp[1] || 0);
-                          break;
-                      }
-                  }
-              }
-          }
-          if (!detected) {
-              browser.others = true;
-          }
-      }
-  };
+            if (rIE11.exec(userAgent)) {
+                browser.msie = true;
+                browser.version = 11;
+                detected = true;
+            } else if (rEdge.exec(userAgent)) {
+                browser.edge = true;
+                browser.version = userAgent.match(rEdge)[1];
+                detected = true;
+            } else {
+                for (key in versionRegex) {
+                    if (versionRegex.hasOwnProperty(key)) {
+                        tmp = userAgent.match(versionRegex[key]);
+                        if (tmp && tmp.length > 1) { // eslint-disable-line max-depth
+                            browser[key] = detected = true;
+                            browser.version = parseFloat(tmp[1] || 0);
+                            break;
+                        }
+                    }
+                }
+            }
+            if (!detected) {
+                browser.others = true;
+            }
+        }
+    };
 
-  var fn = detector[appName];
+    var fn = detector[appName];
 
-  if (fn) {
-      detector[appName]();
-  }
-}
-else {
-  browser.node = true
+    if (fn) {
+        detector[appName]();
+    }
 }
 
 module.exports = browser;


### PR DESCRIPTION
I'm using tui-calendar in an ember app, and when loading it on the server it errors out when calling `window.navigator.appName`, since `window.navigator` is null in the node environment.

This change checks for window and window.navigator, and if those don't exist, it assumes it's the node environment and marks the `browser` object as such.