### PR TITLE
docs: Change document URL (ref: #24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ It includes several features like `class simulation`, `browser detecting`, `type
  * Support utils to define modules
 
 ## Documentation
-* API: [https://nhnent.github.io/tui.code-snippet/latest/](https://nhnent.github.io/tui.code-snippet/latest/)
-* Tutorial: [https://github.com/nhnent/fe.javascript/wiki/Toast-UI-CodeSnippet](https://github.com/nhnent/fe.javascript/wiki/Toast-UI-CodeSnippet)
+* API: [https://nhn.github.io/tui.code-snippet/latest/](https://nhn.github.io/tui.code-snippet/latest/)
+* Tutorial: [https://github.com/nhn/fe.javascript/wiki/Toast-UI-CodeSnippet](https://github.com/nhn/fe.javascript/wiki/Toast-UI-CodeSnippet)
 
 ## Tested Browsers
 * browser:

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ var util = tui.util;
 ```
 
 ### Download
-* [Download bundle files from `dist` folder](https://github.com/nhnent/tui.code-snippet/tree/production/dist)
-* [Download all sources for each version](https://github.com/nhnent/tui.code-snippet/releases)
+* [Download bundle files from `dist` folder](https://github.com/nhn/tui.code-snippet/tree/production/dist)
+* [Download all sources for each version](https://github.com/nhn/tui.code-snippet/releases)
 
 ## License
-[MIT LICENSE](https://github.com/nhnent/tui.code-snippet/blob/master/LICENSE)
+[MIT LICENSE](https://github.com/nhn/tui.code-snippet/blob/master/LICENSE)


### PR DESCRIPTION
nhnent -> nhn

* Github 저장소 URL은 리다이렉트 되지만 github pages는 리다이렉트 되지 않습니다.
Github repository URLs are redirected, but github pages are not redirected.

ref: #24 #26 