### PR TITLE
fix: maintain outer context

### DIFF
--- a/test/template.spec.js
+++ b/test/template.spec.js
@@ -101,7 +101,6 @@ describe('block helper', function() {
     expect(function() {
       return template('{{each arr}}', {});
     }).toThrowError('each needs {{/each}} expression.');
-
     expect(function() {
       return template('{{with 1 as one}}', {});
     }).toThrowError('with needs {{/with}} expression.');
@@ -238,6 +237,12 @@ describe('{{each ...}} @this @index @key {{/each}}', function() {
       second: [4, 5, 6]
     };
     expect(template(source, context)).toBe('456456456');
+
+    source = '{{each doubleArr}}{{each @this}}{{@this}}{{/each}}{{/each}}';
+    context = {
+      doubleArr: [[1, 2, 3], [4, 5, 6]]
+    };
+    expect(template(source, context)).toBe('123456');
   });
 });
 


### PR DESCRIPTION
* Maintain the outer context

## Before (v2.1.0)
```javascript
var source = '{{each doubleArr}}{{each @this}}{{@index}}{{/each}}{{/each}}';
var context = {
  doubleArr: [[1, 2, 3], [4, 5, 6]]
};
console.log(template(source, context)); // ''
// @this in the inner each is undefined because outer context was not applied.
```

## After (v2.1.1)
```javascript
var source = '{{each doubleArr}}{{each @this}}{{@index}}{{/each}}{{/each}}';
var context = {
  doubleArr: [[1, 2, 3], [4, 5, 6]]
};
console.log(template(source, context)); // '012012'
```