### PR TITLE
fix: splitByRegExp for IE8

### DIFF
--- a/collection/forEachArray.js
+++ b/collection/forEachArray.js
@@ -13,7 +13,7 @@
  *  1) The value of the element
  *  2) The index of the element
  *  3) The array(or Array-like object) being traversed
- * @param {Array} arr The array(or Array-like object) that will be traversed
+ * @param {Array|Arguments|NodeList} arr The array(or Array-like object) that will be traversed
  * @param {function} iteratee Callback function
  * @param {Object} [context] Context(this) of callback function
  * @memberof module:collection

--- a/domEvent/off.js
+++ b/domEvent/off.js
@@ -13,11 +13,29 @@ var safeEvent = require('./_safeEvent');
 /**
  * Unbind DOM events
  * If a handler function is not passed, remove all events of that type.
- * @param {HTMLElement} element - element to unbindbind events
- * @param {(string|object)} types - Space splitted events names or
- *  eventName:handler object
+ * @param {HTMLElement} element - element to unbind events
+ * @param {(string|object)} types - Space splitted events names or eventName:handler object
  * @param {function} [handler] - handler function
  * @memberof module:domEvent
+ * @example
+ * // Following the example of {@link domEvent#on on()}
+ * 
+ * // Unbind one event from an element.
+ * off(div, 'click', toggle);
+ * 
+ * // Unbind multiple events with a same handler from multiple elements at once.
+ * // Use event names splitted by a space.
+ * off(element, 'mouseenter mouseleave', changeColor);
+ * 
+ * // Unbind multiple events with different handlers from an element at once.
+ * // Use an object which of key is an event name and value is a handler function.
+ * off(div, {
+ *   keydown: highlight,
+ *   keyup: dehighlight
+ * });
+ * 
+ * // Unbind events without handlers.
+ * off(div, 'drag');
  */
 function off(element, types, handler) {
   if (isString(types)) {

--- a/domEvent/on.js
+++ b/domEvent/on.js
@@ -11,14 +11,36 @@ var forEach = require('../collection/forEach');
 var safeEvent = require('./_safeEvent');
 
 /**
- * Bind DOM events
+ * Bind DOM events.
  * @param {HTMLElement} element - element to bind events
- * @param {(string|object)} types - Space splitted events names or
- *  eventName:handler object
- * @param {(function|object)} handler - handler function or context for handler
- *  method
+ * @param {(string|object)} types - Space splitted events names or eventName:handler object
+ * @param {(function|object)} handler - handler function or context for handler method
  * @param {object} [context] context - context for handler method.
  * @memberof module:domEvent
+ * @example
+ * var div = document.querySelector('div');
+ * 
+ * // Bind one event to an element.
+ * on(div, 'click', toggle);
+ * 
+ * // Bind multiple events with a same handler to multiple elements at once.
+ * // Use event names splitted by a space.
+ * on(div, 'mouseenter mouseleave', changeColor);
+ * 
+ * // Bind multiple events with different handlers to an element at once.
+ * // Use an object which of key is an event name and value is a handler function.
+ * on(div, {
+ *   keydown: highlight,
+ *   keyup: dehighlight
+ * });
+ * 
+ * // Set a context for handler method.
+ * var name = 'global';
+ * var repository = {name: 'CodeSnippet'};
+ * on(div, 'drag', function() {
+ *  console.log(this.name);
+ * }, repository);
+ * // Result when you drag a div: "CodeSnippet"
  */
 function on(element, types, handler, context) {
   if (isString(types)) {
@@ -38,8 +60,7 @@ function on(element, types, handler, context) {
  * Bind DOM events
  * @param {HTMLElement} element - element to bind events
  * @param {string} type - events name
- * @param {function} handler - handler function or context for handler
- *  method
+ * @param {function} handler - handler function or context for handler method
  * @param {object} [context] context - context for handler method.
  * @private
  */

--- a/domUtil/template.js
+++ b/domUtil/template.js
@@ -29,6 +29,8 @@ var BLOCK_HELPERS = {
   'with': handleWith
 };
 
+var isValidSplit = 'a'.split(/a/).length === 3;
+
 /**
  * Split by RegExp. (Polyfill for IE8)
  * @param {string} text - text to be splitted\
@@ -36,7 +38,7 @@ var BLOCK_HELPERS = {
  * @returns {Array.<string>}
  */
 var splitByRegExp = (function() {
-  if ('a'.split(/a/).length === 3) {
+  if (isValidSplit) {
     return function(text, regexp) {
       return text.split(regexp);
     };

--- a/domUtil/template.js
+++ b/domUtil/template.js
@@ -11,10 +11,14 @@ var isArray = require('../type/isArray');
 var isString = require('../type/isString');
 var extend = require('../object/extend');
 
-var EXPRESSION_REGEXP = /{{\s?(\/?[a-zA-Z0-9_.@[\]"'\- ]+)\s?}}/g;
-var BRACKET_REGEXP = /^([a-zA-Z0-9_@]+)\[([a-zA-Z0-9_@"']+)\]$/;
-var DOT_REGEXP = /^([a-zA-Z_]+)\.([a-zA-Z_]+)$/;
-var STRING_REGEXP = /^["'](\w+)["']$/;
+// IE8 does not support capture groups.
+var EXPRESSION_REGEXP = /{{\s?|\s?}}/g;
+var BRACKET_NOTATION_REGEXP = /^[a-zA-Z0-9_@]+\[[a-zA-Z0-9_@"']+\]$/;
+var BRACKET_REGEXP = /\[\s?|\s?\]/;
+var DOT_NOTATION_REGEXP = /^[a-zA-Z_]+\.[a-zA-Z_]+$/;
+var DOT_REGEXP = /\./;
+var STRING_NOTATION_REGEXP = /^["']\w+["']$/;
+var STRING_REGEXP = /"|'/g;
 var NUMBER_REGEXP = /^-?\d+\.?\d*$/;
 
 var EXPRESSION_INTERVAL = 2;
@@ -24,6 +28,42 @@ var BLOCK_HELPERS = {
   'each': handleEach,
   'with': handleWith
 };
+
+/**
+ * Split by RegExp. (Polyfill for IE8)
+ * @param {string} text - text to be splitted\
+ * @param {RegExp} regexp - regular expression
+ * @returns {Array.<string>}
+ */
+var splitByRegExp = (function() {
+  if ('a'.split(/a/).length === 3) {
+    return function(text, regexp) {
+      return text.split(regexp);
+    };
+  }
+
+  return function(text, regexp) {
+    var result = [];
+    var prevIndex = 0;
+    var match, index;
+
+    if (!regexp.global) {
+      regexp = new RegExp(regexp, 'g');
+    }
+
+    match = regexp.exec(text);
+    while (match !== null) {
+      index = match.index;
+      result.push(text.slice(prevIndex, index));
+
+      prevIndex = index + match[0].length;
+      match = regexp.exec(text);
+    }
+    result.push(text.slice(prevIndex));
+
+    return result;
+  };
+})();
 
 /**
  * Find value in the context by an expression.
@@ -41,14 +81,14 @@ function getValueFromContext(exp, context) {
     value = true;
   } else if (exp === 'false') {
     value = false;
-  } else if (STRING_REGEXP.test(exp)) {
-    value = STRING_REGEXP.exec(exp)[1];
-  } else if (BRACKET_REGEXP.test(exp)) {
+  } else if (STRING_NOTATION_REGEXP.test(exp)) {
+    value = exp.replace(STRING_REGEXP, '');
+  } else if (BRACKET_NOTATION_REGEXP.test(exp)) {
     splitedExps = exp.split(BRACKET_REGEXP);
-    value = getValueFromContext(splitedExps[1], context)[getValueFromContext(splitedExps[2], context)];
-  } else if (DOT_REGEXP.test(exp)) {
+    value = getValueFromContext(splitedExps[0], context)[getValueFromContext(splitedExps[1], context)];
+  } else if (DOT_NOTATION_REGEXP.test(exp)) {
     splitedExps = exp.split(DOT_REGEXP);
-    value = getValueFromContext(splitedExps[1], context)[splitedExps[2]];
+    value = getValueFromContext(splitedExps[0], context)[splitedExps[1]];
   } else if (NUMBER_REGEXP.test(exp)) {
     value = parseFloat(exp);
   }
@@ -336,9 +376,7 @@ function compile(sources, context) {
  * console.log(result); // <h1>Date: 2019-11-25</h1><p>1: Clean the room</p><p>2: Wash the dishes</p>
  */
 function template(text, context) {
-  text = text.replace(/\n\s*/g, '');
-
-  return compile(text.split(EXPRESSION_REGEXP), context);
+  return compile(splitByRegExp(text, EXPRESSION_REGEXP), context);
 }
 
 module.exports = template;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -61,8 +61,7 @@ function setConfig(defaultConfig, server) {
       // }
     };
     defaultConfig.browsers = [
-      // @FIXME: localStorage mocking 버그. 이후 수정 필요
-      // 'IE8',
+      'IE8',
       'IE9',
       'IE10',
       'IE11',
@@ -94,9 +93,7 @@ function setConfig(defaultConfig, server) {
       suite: ''
     };
   } else {
-    defaultConfig.browsers = [
-      'ChromeHeadless'
-    ];
+    defaultConfig.browsers = ['ChromeHeadless'];
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "eslint": "eslint \"**/*.js\"",
     "test": "karma start --no-single-run",
     "test:ne": "KARMA_SERVER=ne karma start",
-    "bundle": "webpack & webpack -p",
+    "bundle": "webpack --mode=production & webpack --mode=production --minify",
     "doc:serve": "tuidoc --serv",
     "doc": "tuidoc",
     "note": "tui-note"

--- a/test/request.spec.js
+++ b/test/request.spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var browser = require('../browser/browser');
 var imagePing = require('../request/imagePing');
 var sendHostname = require('../request/sendHostname');
 
@@ -23,75 +24,78 @@ describe('module:request', function() {
     });
   });
 
-  describe('sendHostname', function() {
-    beforeEach(function() {
-      window.tui = window.tui || {};
+  // @TODO: localStorage mocking 버그. 이후 수정 필요
+  if (!(browser.msie && browser.version === 8)) {
+    describe('sendHostname', function() {
+      beforeEach(function() {
+        window.tui = window.tui || {};
 
-      // can not spy on imagePing. spy on appendChild instead.
-      spyOn(document.body, 'appendChild');
-      spyOn(document.body, 'removeChild');
-      spyOn(Storage.prototype, 'getItem').and.returnValue(null);
+        // can not spy on imagePing. spy on appendChild instead.
+        spyOn(document.body, 'appendChild');
+        spyOn(document.body, 'removeChild');
+        spyOn(Storage.prototype, 'getItem').and.returnValue(null);
+      });
+
+      it('should call appendChild', function(done) {
+        sendHostname('editor');
+
+        setTimeout(function() {
+          expect(document.body.appendChild).toHaveBeenCalled();
+          done();
+        }, 1500);
+      });
+
+      it('should not call appendChild', function(done) {
+        window.tui.usageStatistics = false;
+
+        sendHostname('editor');
+
+        setTimeout(function() {
+          expect(document.body.appendChild).not.toHaveBeenCalled();
+          done();
+        }, 1500);
+      });
     });
 
-    it('should call appendChild', function(done) {
-      sendHostname('editor');
+    describe('sendHostname with localstorage', function() {
+      beforeEach(function() {
+        window.tui = window.tui || {};
 
-      setTimeout(function() {
-        expect(document.body.appendChild).toHaveBeenCalled();
-        done();
-      }, 1500);
+        // can not spy on imagePing. spy on appendChild instead.
+        spyOn(document.body, 'appendChild');
+        spyOn(document.body, 'removeChild');
+      });
+
+      it('should not call appendChild within 7 days', function(done) {
+        var now = new Date().getTime();
+        var ms6days = 6 * 24 * 60 * 60 * 1000;
+
+        spyOn(Storage.prototype, 'getItem').and.returnValue(now - ms6days);
+
+        window.tui.usageStatistics = true;
+
+        sendHostname('editor');
+
+        setTimeout(function() {
+          expect(document.body.appendChild).not.toHaveBeenCalled();
+          done();
+        }, 1500);
+      });
+
+      it('should call appendChild after 7 days', function(done) {
+        var now = new Date().getTime();
+        var ms8days = 8 * 24 * 60 * 60 * 1000;
+        spyOn(Storage.prototype, 'getItem').and.returnValue(now - ms8days);
+
+        window.tui.usageStatistics = true;
+
+        sendHostname('editor');
+
+        setTimeout(function() {
+          expect(document.body.appendChild).toHaveBeenCalled();
+          done();
+        }, 1500);
+      });
     });
-
-    it('should not call appendChild', function(done) {
-      window.tui.usageStatistics = false;
-
-      sendHostname('editor');
-
-      setTimeout(function() {
-        expect(document.body.appendChild).not.toHaveBeenCalled();
-        done();
-      }, 1500);
-    });
-  });
-
-  describe('sendHostname with localstorage', function() {
-    beforeEach(function() {
-      window.tui = window.tui || {};
-
-      // can not spy on imagePing. spy on appendChild instead.
-      spyOn(document.body, 'appendChild');
-      spyOn(document.body, 'removeChild');
-    });
-
-    it('should not call appendChild within 7 days', function(done) {
-      var now = new Date().getTime();
-      var ms6days = 6 * 24 * 60 * 60 * 1000;
-
-      spyOn(Storage.prototype, 'getItem').and.returnValue(now - ms6days);
-
-      window.tui.usageStatistics = true;
-
-      sendHostname('editor');
-
-      setTimeout(function() {
-        expect(document.body.appendChild).not.toHaveBeenCalled();
-        done();
-      }, 1500);
-    });
-
-    it('should call appendChild after 7 days', function(done) {
-      var now = new Date().getTime();
-      var ms8days = 8 * 24 * 60 * 60 * 1000;
-      spyOn(Storage.prototype, 'getItem').and.returnValue(now - ms8days);
-
-      window.tui.usageStatistics = true;
-
-      sendHostname('editor');
-
-      setTimeout(function() {
-        expect(document.body.appendChild).toHaveBeenCalled();
-        done();
-      }, 1500);
-    });
-  });
+  }
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,10 +8,30 @@
 var path = require('path');
 var pkg = require('./package.json');
 var webpack = require('webpack');
+var TerserPlugin = require('terser-webpack-plugin');
+
+function setOptimization(isMinified) {
+  if (isMinified) {
+    return {
+      minimizer: [
+        new TerserPlugin({
+          cache: true,
+          parallel: true,
+          sourceMap: false,
+          extractComments: false
+        })
+      ]
+    };
+  }
+
+  return {
+    minimize: false
+  };
+}
 
 module.exports = function(env, argv) {
-  var isProduction = argv.mode === 'production';
-  var FILENAME = pkg.name + (isProduction ? '.min.js' : '.js');
+  var isMinified = !!argv.minify;
+  var FILENAME = pkg.name + (isMinified ? '.min.js' : '.js');
   var BANNER = [
     'TOAST UI Code Snippet',
     '@version ' + pkg.version,
@@ -20,7 +40,7 @@ module.exports = function(env, argv) {
   ].join('\n');
 
   return {
-    mode: 'development',
+    mode: 'production',
     entry: './index.js',
     output: {
       library: ['tui', 'util'],
@@ -36,13 +56,14 @@ module.exports = function(env, argv) {
           exclude: /node_modules/,
           loader: 'eslint-loader',
           options: {
-            failOnError: isProduction
+            failOnError: true
           }
         }
       ]
     },
     plugins: [
       new webpack.BannerPlugin(BANNER)
-    ]
+    ],
+    optimization: setOptimization(isMinified)
   };
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ var pkg = require('./package.json');
 var webpack = require('webpack');
 var TerserPlugin = require('terser-webpack-plugin');
 
-function setOptimization(isMinified) {
+function getOptimization(isMinified) {
   if (isMinified) {
     return {
       minimizer: [
@@ -64,6 +64,6 @@ module.exports = function(env, argv) {
     plugins: [
       new webpack.BannerPlugin(BANNER)
     ],
-    optimization: setOptimization(isMinified)
+    optimization: getOptimization(isMinified)
   };
 };


### PR DESCRIPTION
## Other browsers except IE8
```javascript
var regexp = '/{{|}}/'
console.log(splitByRegExp('{{test}}', regexp)); // ['', 'test', '']
```

## Before (IE8)
```javascript
var regexp = '/{{|}}/';
console.log('{{test}}'.split(regexp)); // ['test']
```

## After (IE8)
```javascript
var regexp = '/{{|}}/'
console.log(splitByRegExp('{{test}}', regexp)); // ['', 'test', '']
```