### PR TITLE
chore: exclude IE8 test

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -61,7 +61,7 @@ function setConfig(defaultConfig, server) {
       // }
     };
     defaultConfig.browsers = [
-      'IE8',
+      // 'IE8',
       'IE9',
       'IE10',
       'IE11',


### PR DESCRIPTION
When the test is run, the socket is not connected even if Karma is starting.